### PR TITLE
Fix "Could not compile resource file" error when cross-compiling on macOS.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
+use std::path::PathBuf;
 use winresource::WindowsResource;
 
 fn main() {
+    let res_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("res").join("eventmsgs.rc");
     WindowsResource::new()
-        .set_resource_file("res/eventmsgs.rc")
+        .set_resource_file(res_path.to_str().unwrap())
         .compile()
         .unwrap();
 }


### PR DESCRIPTION
Fix "Could not compile resource file" error when cross-compiling on macOS by ensuring correct resource file path resolution using CARGO_MANIFEST_DIR environment variable.

Error details:
```
parsle@iMac-Pro winlog % cargo build --target x86_64-pc-windows-gnu
   Compiling winlog2 v0.3.1 (/Users/parsle/Code/winlog)
error: failed to run custom build command for `winlog2 v0.3.1 (/Users/parsle/Code/winlog)`

Caused by:
  process didn't exit successfully: `/Users/parsle/Code/winlog/target/debug/build/winlog2-a998e6b3fd31c500/build-script-build` (exit status: 101)
  --- stdout
  package.metadata.winresource does not exist

  --- stderr
  cc1: fatal error: res/eventmsgs.rc: No such file or directory
  compilation terminated.
  x86_64-w64-mingw32-windres: preprocessing failed.
  thread 'main' panicked at build.rs:7:10:
  called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "Could not compile resource file" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```